### PR TITLE
Create table and fix text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,227 +1,29 @@
-# What is this?
 
-This is a language agnostic way to identify file types by their magic numbers.
+# Magic Bytes
+A simple library for identifying file types by their magic bytes.
 
-This supports every signature in https://en.wikipedia.org/wiki/List_of_file_signatures, with some changes & additions.
-
-For usage, see the [examples directory](./examples).
-
-## Different files
-
-- [file_sigs.csv](./file_sigs.csv) is the source of truth for file signatures.
-- [dist/rows_map.json](./dist/rows_map.json) is a map of all the file signatures, except those in `offset_list.json`, it's primarily used for generating `lookup_map.json`.
-- [dist/offset_list.json](./dist/offset_list.json) is a list of all the file signatures that need to be checked at a specific offset.
-- [dist/lookup_map.json](./dist/lookup_map.json) is a lookup map of all the file signatures, except those in `offset_list.json`. It's used to quickly lookup a signature of unknown length.
-
-# Extensions
-
-## Additions
-
-Add new extensions by modifying [file_sigs.csv](./file_sigs.csv), put it in this list, then run `python3 convert.py`. Afterwards, submit a PR. All contributions are loved and welcome.
-
-- svg
-
-## Supported extensions (shortened, see CSV for full list)
-
-- pcap
-- pcapng
-- rpm
-- sqlitedb
-- bin
-- wad
-- PDB
-- DBA
-- TDA
-- TDF$
-- TDEF
-- ico
-- icns
-- 3gp
-- z
-- lzh
-- bac
-- idx
-- plist
-- bz2
-- gif
-- tif
-- cr2
-- cin
-- nui
-- dpx
-- exr
-- bpg
-- jpg
-- jp2
-- ilbm
-- 8svx
-- acbm
-- anbm
-- anim
-- faxx
-- ftxt
-- smus
-- cmus
-- yuvn
-- iff
-- aiff
-- lz
-- cpio
-- exe
-- zip
-- rar
-- png
-- com
-- class
-- txt
-- ps
-- eps
-- chm
-- hlp
-- pdf
-- asf
-- ogg
-- psd
-- wav
-- avi
-- mp3
-- bmp
-- iso
-- cdi
-- mgw
-- nes
-- d64
-- g64
-- d81
-- t64
-- crt
-- fits
-- flac
-- mid
-- doc
-- dex
-- vmdk
-- crx
-- fh8
-- cwk
-- toast
-- dmg
-- xar
-- dat
-- tar
-- oar
-- tox
-- MLV
-- 7z
-- gz
-- xz
-- lz4
-- cab
-- ??_
-- flif
-- mkv
-- stg
-- djvu
-- der
-- csr
-- key
-- ppk
-- pub
-- dcm
-- woff
-- woff2
-- xml
-- wasm
-- lep
-- swf
-- deb
-- webp
-- rtf
-- ts
-- m2p
-- mpg
-- mp4
-- zlib
-- lzfse
-- orc
-- avro
-- rc
-- p25
-- pcv
-- pbt
-- ez2
-- ez3
-- luac
-- alias
-- Identifier
-- eml
-- tde
-- kdb
-- pgp
-- zst
-- rs
-- sml
-- srt
-- vpk
-- ace
-- arj
-- zoo
-- pbm
-- pgm
-- ppm
-- wmf
-- xcf
-- xpm
-- aff
-- Ex01
-- e01
-- qcow
-- ani
-- cda
-- qcp
-- dcr
-- dir
-- flv
-- vdi
-- vhd
-- vhdx
-- isz
-- daa
-- evt
-- evtx
-- sdb
-- grp
-- icm
-- pst
-- drc
-- grib
-- blend
-- jxl
-- ttf
-- otf
-- wim
-- slob
-- voc
-- au
-- hazelrules
-- flp
-- flm
-- mny
-- accdb
-- mdb
-- drw
-- dss
-- adx
-- indd
-- skf
-- dtd
-- wallet
-- nri
-- wks
-- sib
-- dsp
-- amr
-- sil
-- hdr
-- vbe
-- cdb
+## Supported Extensions
+| Extension | Description | File Type |
+| --------- | ----------- | --------- |
+| .7z       | 7-Zip File Format | Archive |
+| .bz2      | Bzip2 Compressed File | Archive |
+| .gz       | Gzip Compressed File | Archive |
+| .rar      | RAR Archive File | Archive |
+| .tar      | Tape Archive File | Archive |
+| .tar.gz   | Compressed Tarball File | Archive |
+| .zip      | ZIP Archive File | Archive |
+| .class    | Java Class File | Executable |
+| .crx      | Chrome Extension File | Executable |
+| .elf      | Executable and Linkable Format File | Executable |
+| .exe      | Windows Executable File | Executable |
+| .bmp      | Bitmap Image File | Image |
+| .cr2      | Canon Raw Image File | Image |
+| .flif     | Free Lossless Image Format File | Image |
+| .gif      | Graphical Interchange Format File | Image |
+| .ico      | Icon File | Image |
+| .jpg      | JPEG Image File | Image |
+| .png      | Portable Network Graphics File | Image |
+| .tif      | Tagged Image File Format | Image |
+| .webp     | WebP Image File | Image |
+| .eot      | Embedded OpenType Font File | Font |
+| .otf      | OpenType Font File

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ For usage, see the [examples directory](./examples).
 
 Add new extensions by modifying [file_sigs.csv](./file_sigs.csv), put it in this list, then run `python3 convert.py`. Afterwards, submit a PR. All contributions are loved and welcome.
 
-- svg
-
 ## Supported extensions (shortened, see CSV for full list)
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
+# What is this?
 
-# Magic Bytes
-A simple library for identifying file types by their magic bytes.
+This is a language agnostic way to identify file types by their magic numbers.
 
-## Supported Extensions
+This supports every signature in https://en.wikipedia.org/wiki/List_of_file_signatures, with some changes & additions.
+
+For usage, see the [examples directory](./examples).
+
+## Different files
+
+- [file_sigs.csv](./file_sigs.csv) is the source of truth for file signatures.
+- [dist/rows_map.json](./dist/rows_map.json) is a map of all the file signatures, except those in `offset_list.json`, it's primarily used for generating `lookup_map.json`.
+- [dist/offset_list.json](./dist/offset_list.json) is a list of all the file signatures that need to be checked at a specific offset.
+- [dist/lookup_map.json](./dist/lookup_map.json) is a lookup map of all the file signatures, except those in `offset_list.json`. It's used to quickly lookup a signature of unknown length.
+
+# Extensions
+
+## Additions
+
+Add new extensions by modifying [file_sigs.csv](./file_sigs.csv), put it in this list, then run `python3 convert.py`. Afterwards, submit a PR. All contributions are loved and welcome.
+
+- svg
+
+## Supported extensions (shortened, see CSV for full list)
+
+
 | Extension | Description | File Type |
 | --------- | ----------- | --------- |
 | .7z       | 7-Zip File Format | Archive |
@@ -23,7 +44,8 @@ A simple library for identifying file types by their magic bytes.
 | .ico      | Icon File | Image |
 | .jpg      | JPEG Image File | Image |
 | .png      | Portable Network Graphics File | Image |
+| .svg      | Scalable Vector Graphics File | Image |
 | .tif      | Tagged Image File Format | Image |
 | .webp     | WebP Image File | Image |
 | .eot      | Embedded OpenType Font File | Font |
-| .otf      | OpenType Font File | Font |
+| .otf      | OpenType Font File

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ A simple library for identifying file types by their magic bytes.
 | .tif      | Tagged Image File Format | Image |
 | .webp     | WebP Image File | Image |
 | .eot      | Embedded OpenType Font File | Font |
-| .otf      | OpenType Font File
+| .otf      | OpenType Font File | Font |


### PR DESCRIPTION
I updated the readme to organize the different file types into a table as well as noticed ".svg" was in the wrong position so I updated that inside the readme